### PR TITLE
init flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,23 @@ This tool is under development and may change.
 
 ## Installation
 
+Using pip:
+
 ```
 $ pip install supernotelib
 ```
 
+Using Nix (with Flakes enabled):
+
+```
+$ nix profile install .
+```
+
+or just run it without installing:
+
+```
+$ nix run github:jya-dev/supernote-tool -- convert your.note output.png
+```
 
 ## Usage
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+    description = "Unofficial python tool for Ratta Supernote";
+
+    inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs =
+        {
+            self,
+            nixpkgs,
+            flake-utils,
+        }:
+        flake-utils.lib.eachDefaultSystem (
+            system:
+            let
+                pkgs = import nixpkgs { inherit system; };
+                python = pkgs.python3;
+
+                potracer = python.pkgs.buildPythonPackage rec {
+                    pname = "potracer";
+                    version = "0.0.1";
+                    format = "setuptools";
+
+                    src = python.pkgs.fetchPypi {
+                        inherit pname version;
+                        sha256 = "057wz5368nfwklaajdcc738x983978ash8xqnf9b378m614vgf9c";
+                    };
+
+                    propagatedBuildInputs = with python.pkgs; [
+                        numpy
+                    ];
+
+                    doCheck = false;
+                };
+
+                supernote-tool = python.pkgs.buildPythonApplication rec {
+                    pname = "supernotelib";
+                    version = "0.7.1";
+                    pyproject = true;
+
+                    src = ./.;
+
+                    nativeBuildInputs = with python.pkgs; [
+                        hatchling
+                    ];
+
+                    propagatedBuildInputs = with python.pkgs; [
+                        colour
+                        fusepy
+                        numpy
+                        pillow
+                        potracer
+                        pypng
+                        reportlab
+                        svglib
+                        svgwrite
+                    ];
+
+                    doCheck = false;
+                };
+            in
+            {
+                packages.default = supernote-tool;
+                packages.supernote-tool = supernote-tool;
+
+                apps.default = {
+                    type = "app";
+                    program = "${supernote-tool}/bin/supernote-tool";
+                };
+
+                apps.supernote-fuse = {
+                    type = "app";
+                    program = "${supernote-tool}/bin/supernote-fuse";
+                };
+
+                devShells.default = pkgs.mkShell {
+                    inputsFrom = [ supernote-tool ];
+                };
+            }
+        );
+}


### PR DESCRIPTION
This PR adds support for Nix Flakes to make the installation, usage, and development setup of  supernote-tool  easier and more reproducible.
Further you can easily install this application or even run it without installation.
  
 ## Changes Proposed:
  
  • Nix Flake Integration: Added a flake.nix file to package  supernote-tool .
      • Exposes default packages and apps for both  supernote-tool  and  supernote-fuse .
      • Custom-packages  potracer  (pure-python port of Potrace from PyPI) which was missing from upstream Nixpkgs.
      • Sets up a development shell ( nix develop ) with all Python dependencies ready to go.
  • Documentation: Updated the README.md file to add Nix installation and run instructions under the "Installation" section. 

##  How to Test
  
 ### Install locally
  
    nix profile install .
    
### Run directly from local directory
  
    nix run . -- --help
    nix run .#supernote-fuse -- --help
    
### Run directly from GitHub branch (after merge/push)
  
    nix run github:username/supernote-tool -- --help