### PR TITLE
Fix right horizontal orientation detection

### DIFF
--- a/supernotelib/fileformat.py
+++ b/supernotelib/fileformat.py
@@ -326,6 +326,7 @@ class Page:
 
     ORIENTATION_VERTICAL = "1000"
     ORIENTATION_HORIZONTAL = "1090"
+    ORIENTATION_HORIZONTAL_ALT = "1270"
 
     def __init__(self, page_info):
         self.metadata = page_info
@@ -418,7 +419,10 @@ class Page:
         return self.recogn_text
 
     def get_orientation(self):
-        return self.metadata.get('ORIENTATION', self.ORIENTATION_VERTICAL)
+        orientation = self.metadata.get('ORIENTATION', self.ORIENTATION_VERTICAL)
+        if orientation == self.ORIENTATION_HORIZONTAL_ALT:
+            return self.ORIENTATION_HORIZONTAL
+        return orientation
 
 class Layer:
     def __init__(self, layer_info):


### PR DESCRIPTION
The current `get_orientation` method only detects vertical and left horizontal orientation. When the device is in right horizontal orientation, it causes pages to decode with the wrong bitmap stride producing distorted outputs.

## Fix Proposed:
```python
ORIENTATION_HORIZONTAL_ALT = "1270"

def get_orientation(self):
    orientation = self.metadata.get('ORIENTATION', self.ORIENTATION_VERTICAL)
    if orientation == self.ORIENTATION_HORIZONTAL_ALT:
        return self.ORIENTATION_HORIZONTAL
    return orientation
```